### PR TITLE
feat: add custom API auth method

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ If you need to use a specific model or require a higher request capacity, you ca
    export GEMINI_API_KEY="YOUR_API_KEY"
    ```
 
+To use another compatible provider, set `CUSTOM_API_BASE_URL` and `CUSTOM_API_KEY` and choose **Custom API** when prompted:
+
+```bash
+export CUSTOM_API_BASE_URL="https://your-provider.example.com"
+export CUSTOM_API_KEY="YOUR_CUSTOM_API_KEY"
+```
+
 For other authentication methods, including Google Workspace accounts, see the [authentication](./docs/cli/authentication.md) guide.
 
 ## Examples

--- a/docs/cli/authentication.md
+++ b/docs/cli/authentication.md
@@ -90,3 +90,18 @@ The Gemini CLI requires you to authenticate with Google's AI services. On initia
           echo 'export GOOGLE_GENAI_USE_VERTEXAI=true' >> ~/.bashrc
           source ~/.bashrc
           ```
+
+5.  **Custom API:**
+    - Use this option to connect to a Gemini-compatible provider using your own API endpoint and key.
+    - Set the `CUSTOM_API_BASE_URL` and `CUSTOM_API_KEY` environment variables. Replace the placeholders with your provider's base URL and API key.
+      - Temporarily for the current shell session:
+        ```bash
+        export CUSTOM_API_BASE_URL="https://your-provider.example.com"
+        export CUSTOM_API_KEY="YOUR_CUSTOM_API_KEY"
+        ```
+      - For repeated use, add these variables to your `.env` file or shell configuration (like `~/.bashrc`, `~/.zshrc`, or `~/.profile`). For example:
+        ```bash
+        echo 'export CUSTOM_API_BASE_URL="https://your-provider.example.com"' >> ~/.bashrc
+        echo 'export CUSTOM_API_KEY="YOUR_CUSTOM_API_KEY"' >> ~/.bashrc
+        source ~/.bashrc
+        ```

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -35,5 +35,14 @@ export const validateAuthMethod = (authMethod: string): string | null => {
     return null;
   }
 
+  if (authMethod === AuthType.USE_CUSTOM) {
+    if (!process.env.CUSTOM_API_KEY || !process.env.CUSTOM_API_BASE_URL) {
+      return (
+        'CUSTOM_API_KEY and CUSTOM_API_BASE_URL environment variables not found. Add them to your .env and try again, no reload needed!'
+      );
+    }
+    return null;
+  }
+
   return 'Invalid auth method selected.';
 };

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -35,6 +35,7 @@ export function AuthDialog({
     },
     { label: 'Gemini API Key', value: AuthType.USE_GEMINI },
     { label: 'Vertex AI', value: AuthType.USE_VERTEX_AI },
+    { label: 'Custom API', value: AuthType.USE_CUSTOM },
   ];
 
   let initialAuthIndex = items.findIndex(

--- a/packages/cli/src/ui/utils/errorParsing.test.ts
+++ b/packages/cli/src/ui/utils/errorParsing.test.ts
@@ -48,6 +48,14 @@ describe('parseAndFormatApiError', () => {
     expect(result).toContain(vertexMessage);
   });
 
+  it('should format a 429 API error with the default message for custom auth', () => {
+    const errorMessage =
+      'got status: 429 Too Many Requests. {"error":{"code":429,"message":"Rate limit exceeded","status":"RESOURCE_EXHAUSTED"}}';
+    const result = parseAndFormatApiError(errorMessage, AuthType.USE_CUSTOM);
+    expect(result).toContain('[API Error: Rate limit exceeded');
+    expect(result).toContain('Your request has been rate limited');
+  });
+
   it('should return the original message if it is not a JSON error', () => {
     const errorMessage = 'This is a plain old error message';
     expect(parseAndFormatApiError(errorMessage)).toBe(

--- a/packages/cli/src/ui/utils/errorParsing.ts
+++ b/packages/cli/src/ui/utils/errorParsing.ts
@@ -51,6 +51,8 @@ function getRateLimitMessage(authType?: AuthType): string {
       return RATE_LIMIT_ERROR_MESSAGE_USE_GEMINI;
     case AuthType.USE_VERTEX_AI:
       return RATE_LIMIT_ERROR_MESSAGE_VERTEX;
+    case AuthType.USE_CUSTOM:
+      return RATE_LIMIT_ERROR_MESSAGE_DEFAULT;
     default:
       return RATE_LIMIT_ERROR_MESSAGE_DEFAULT;
   }

--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -47,4 +47,28 @@ describe('contentGenerator', () => {
     });
     expect(generator).toBe((mockGenerator as GoogleGenAI).models);
   });
+
+  it('should create a GoogleGenAI content generator with custom base URL', async () => {
+    const mockGenerator = {
+      models: {},
+    } as unknown;
+    vi.mocked(GoogleGenAI).mockImplementation(() => mockGenerator as never);
+    const generator = await createContentGenerator({
+      model: 'test-model',
+      apiKey: 'test-api-key',
+      baseUrl: 'https://example.com',
+      authType: AuthType.USE_CUSTOM,
+    });
+    expect(GoogleGenAI).toHaveBeenCalledWith({
+      apiKey: 'test-api-key',
+      vertexai: undefined,
+      httpOptions: {
+        headers: {
+          'User-Agent': expect.any(String),
+        },
+        baseUrl: 'https://example.com',
+      },
+    });
+    expect(generator).toBe((mockGenerator as GoogleGenAI).models);
+  });
 });

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -38,12 +38,14 @@ export enum AuthType {
   LOGIN_WITH_GOOGLE_PERSONAL = 'oauth-personal',
   USE_GEMINI = 'gemini-api-key',
   USE_VERTEX_AI = 'vertex-ai',
+  USE_CUSTOM = 'custom-api',
 }
 
 export type ContentGeneratorConfig = {
   model: string;
   apiKey?: string;
   vertexai?: boolean;
+  baseUrl?: string;
   authType?: AuthType | undefined;
 };
 
@@ -56,6 +58,8 @@ export async function createContentGeneratorConfig(
   const googleApiKey = process.env.GOOGLE_API_KEY;
   const googleCloudProject = process.env.GOOGLE_CLOUD_PROJECT;
   const googleCloudLocation = process.env.GOOGLE_CLOUD_LOCATION;
+  const customApiKey = process.env.CUSTOM_API_KEY;
+  const customBaseUrl = process.env.CUSTOM_API_BASE_URL;
 
   // Use runtime model from config if available, otherwise fallback to parameter or default
   const effectiveModel = config?.getModel?.() || model || DEFAULT_GEMINI_MODEL;
@@ -97,6 +101,12 @@ export async function createContentGeneratorConfig(
     return contentGeneratorConfig;
   }
 
+  if (authType === AuthType.USE_CUSTOM && customApiKey && customBaseUrl) {
+    contentGeneratorConfig.apiKey = customApiKey;
+    contentGeneratorConfig.baseUrl = customBaseUrl;
+    return contentGeneratorConfig;
+  }
+
   return contentGeneratorConfig;
 }
 
@@ -108,14 +118,18 @@ export async function createContentGenerator(
     headers: {
       'User-Agent': `GeminiCLI/${version} (${process.platform}; ${process.arch})`,
     },
-  };
+  } as { headers: Record<string, string>; baseUrl?: string };
+  if (config.baseUrl) {
+    httpOptions.baseUrl = config.baseUrl;
+  }
   if (config.authType === AuthType.LOGIN_WITH_GOOGLE_PERSONAL) {
     return createCodeAssistContentGenerator(httpOptions, config.authType);
   }
 
   if (
     config.authType === AuthType.USE_GEMINI ||
-    config.authType === AuthType.USE_VERTEX_AI
+    config.authType === AuthType.USE_VERTEX_AI ||
+    config.authType === AuthType.USE_CUSTOM
   ) {
     const googleGenAI = new GoogleGenAI({
       apiKey: config.apiKey === '' ? undefined : config.apiKey,

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -56,7 +56,9 @@ export class StartSessionEvent {
     let useGemini = false;
     let useVertex = false;
     if (generatorConfig && generatorConfig.authType) {
-      useGemini = generatorConfig.authType === AuthType.USE_GEMINI;
+      useGemini =
+        generatorConfig.authType === AuthType.USE_GEMINI ||
+        generatorConfig.authType === AuthType.USE_CUSTOM;
       useVertex = generatorConfig.authType === AuthType.USE_VERTEX_AI;
     }
 

--- a/packages/core/src/utils/getFolderStructure.test.ts
+++ b/packages/core/src/utils/getFolderStructure.test.ts
@@ -31,18 +31,19 @@ vi.mock('./gitUtils.js');
 import * as path from 'path';
 
 // Helper to create Dirent-like objects for mocking fs.readdir
-const createDirent = (name: string, type: 'file' | 'dir'): FSDirent => ({
-  name,
-  isFile: () => type === 'file',
-  isDirectory: () => type === 'dir',
-  isBlockDevice: () => false,
-  isCharacterDevice: () => false,
-  isSymbolicLink: () => false,
-  isFIFO: () => false,
-  isSocket: () => false,
-  path: '',
-  parentPath: '',
-});
+const createDirent = (name: string, type: 'file' | 'dir'): FSDirent =>
+  ({
+    name,
+    isFile: () => type === 'file',
+    isDirectory: () => type === 'dir',
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isSymbolicLink: () => false,
+    isFIFO: () => false,
+    isSocket: () => false,
+    path: '',
+    parentPath: '',
+  } as unknown as FSDirent);
 
 describe('getFolderStructure', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- add `USE_CUSTOM` auth type for base URL + key providers
- expose Custom API option in auth dialog and docs
- support telemetry and rate limit messages for custom auth

## Testing
- `npm test` *(fails: TypeError: Cannot convert undefined or null to object in src/tools/mcp-client.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c0178da888832180ea9bcce4cdf10f